### PR TITLE
Make the `drop` event bubble

### DIFF
--- a/lib/dropybara.rb
+++ b/lib/dropybara.rb
@@ -27,6 +27,7 @@ module Capybara
             data.types = ['Files'];
 
             var event = new DragEvent('drop', {
+              bubbles: true,
               target: target,
               dataTransfer: data
             });

--- a/spec/dropybara_spec.rb
+++ b/spec/dropybara_spec.rb
@@ -11,6 +11,12 @@ describe :drop_file, js: true do
     expect(page).to have_content 'upload.txt'
   end
 
+  it 'can drop a file on a child element and because of bubbling it would still work' do
+    page.drop_file '#sub-dropzone', File.expand_path('spec/files/upload.txt')
+
+    expect(page).to have_content 'upload.txt'
+  end
+
   it 'removes the temporary input it uses' do
     page.drop_file '#dropzone', File.expand_path('spec/files/upload.txt')
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -3,7 +3,7 @@
     <title>Dropybara test page</title>
   </head>
   <body>
-    <div id="dropzone"></div>
+    <div id="dropzone"><div id="sub-dropzone"></div></div>
     <ol id="list"></ol>
 
     <script type="text/javascript">


### PR DESCRIPTION
This simplifies usage (because a user doesn't have to target the exact element) and also makes it work correctly for frameworks which dispatch events by catching all on the `body`.